### PR TITLE
RNG seeding using crypto/rand uint64

### DIFF
--- a/fastrand.go
+++ b/fastrand.go
@@ -6,8 +6,9 @@
 package fastrand
 
 import (
+	"crypto/rand"
+	"encoding/binary"
 	"sync"
-	"time"
 )
 
 // Uint32 returns pseudorandom uint32.
@@ -68,6 +69,8 @@ func (r *RNG) Uint32n(maxN uint32) uint32 {
 }
 
 func getRandomUint32() uint32 {
-	x := time.Now().UnixNano()
+	b := make([]byte, 8)
+	_, _ = rand.Read(b)
+	x := binary.BigEndian.Uint64(b)
 	return uint32((x >> 32) ^ x)
 }

--- a/fastrand_test.go
+++ b/fastrand_test.go
@@ -5,13 +5,22 @@ import (
 )
 
 func TestUint32(t *testing.T) {
-	m := make(map[uint32]struct{})
+	m := make(map[uint32]int)
 	for i := 0; i < 1e6; i++ {
 		n := Uint32()
-		if _, ok := m[n]; ok {
-			t.Fatalf("number %v already exists", n)
+		m[n]++
+	}
+
+	const minUniqueValues = 0.9 * 1e6
+	if len(m) < minUniqueValues {
+		t.Errorf("only %d unique numbers were generated", len(m))
+	}
+
+	const maxRepetition = 3
+	for number, count := range m {
+		if count > maxRepetition {
+			t.Errorf("number %d was generated %d times", number, count)
 		}
-		m[n] = struct{}{}
 	}
 }
 

--- a/fastrand_test.go
+++ b/fastrand_test.go
@@ -25,7 +25,9 @@ func TestUint32(t *testing.T) {
 }
 
 func TestRNGUint32(t *testing.T) {
-	var r RNG
+	r := RNG{
+		x: getRandomUint32(),
+	}
 	m := make(map[uint32]struct{})
 	for i := 0; i < 1e6; i++ {
 		n := r.Uint32()
@@ -60,7 +62,9 @@ func TestUint32n(t *testing.T) {
 }
 
 func TestRNGUint32n(t *testing.T) {
-	var r RNG
+	r := RNG{
+		x: getRandomUint32(),
+	}
 	m := make(map[uint32]int)
 	for i := 0; i < 1e6; i++ {
 		n := r.Uint32n(1e2)

--- a/fastrand_timing_test.go
+++ b/fastrand_timing_test.go
@@ -128,3 +128,9 @@ func BenchmarkMathRandRNGInt31nArray(b *testing.B) {
 		atomic.AddUint32(&BenchSink, s)
 	})
 }
+
+func Benchmark_getRandomUint32(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		getRandomUint32()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/valyala/fastrand
+
+go 1.16


### PR DESCRIPTION
- To rebase once #1, #2 and #3 are merged.
- It was taking `127ns` before it now takes `550ns` but this is only done once per RNG
- I think this is very much reasonable as no user would create a very large number (billions+) of goroutines. And it allows our RNGs to be seeded properly 👍 
